### PR TITLE
Fix USA pollen data by switching to GetPollenContentNACity API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ Use this integratiion at your own risk. Kleemex/Scottex may update or modify its
 
 ## Contributions
  * [hocuspocus69](https://github.com/hocuspocus69) &#8594; Added the Italian version.
+ * [castellotti](https://github.com/castellotti) &#8594; Added support for the US API.
 
 [commits-shield]: https://img.shields.io/github/commit-activity/y/MarcoGos/kleenex_pollenradar.svg?style=for-the-badge
 [commits]: https://github.com/MarcoGos/kleenex_pollenradar/commits/main

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ If the Kleenex integration raises errors then first have a look at the Kleenex/S
 - For Italy: https://www.it.scottex.com/allerta-pollini/previsioni-dei-pollini
 - For Netherlands: https://www.kleenex.nl/pollenradar
 - For UK and RoI: https://www.kleenex.co.uk/pollen-count
-- For USA: https://www.kleenex.com/en-us/pollen-count [^1]
+- For USA: https://www.kleenex.com/en-us/pollen-count
 
 ## Disclaimer
 
@@ -75,4 +75,3 @@ Use this integratiion at your own risk. Kleemex/Scottex may update or modify its
 [vdbrink]: https://vdbrink.github.io/homeassistant/homeassistant_hacs_kleenex
 [krissen]: https://github.com/krissen/pollenprognos-card
 
-[^1]: The USA version of the Kleenex pollen radar uses a different version of the API, which is incompatible with the integration. This integration uses an older version of the Kleenex/Scottex API. As a result, the pollen values shown in Home Assistant may differ from those displayed on the official website.

--- a/custom_components/kleenex_pollenradar/__init__.py
+++ b/custom_components/kleenex_pollenradar/__init__.py
@@ -14,6 +14,7 @@ from .const import (
     CONF_GET_CONTENT_BY,
     CONF_CITY,
     GetContentBy,
+    Regions,
 )
 from .coordinator import PollenDataUpdateCoordinator
 
@@ -52,6 +53,17 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
     ):
         hass.data[DOMAIN].pop(config_entry.entry_id)
     return unload_ok
+
+
+async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
+    """Migrate old config entries to the current version."""
+    if config_entry.version == 1:
+        new_data = {**config_entry.data}
+        if new_data.get(CONF_REGION) == Regions.UNITED_STATES.value:
+            new_data[CONF_GET_CONTENT_BY] = GetContentBy.CITY_NA.value
+        hass.config_entries.async_update_entry(config_entry, data=new_data, version=2)
+
+    return True
 
 
 async def async_reload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> None:

--- a/custom_components/kleenex_pollenradar/__init__.py
+++ b/custom_components/kleenex_pollenradar/__init__.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import logging
+
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
@@ -17,6 +19,8 @@ from .const import (
     Regions,
 )
 from .coordinator import PollenDataUpdateCoordinator
+
+_LOGGER = logging.getLogger(__name__)
 
 
 async def async_setup_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
@@ -58,9 +62,16 @@ async def async_unload_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> 
 async def async_migrate_entry(hass: HomeAssistant, config_entry: ConfigEntry) -> bool:
     """Migrate old config entries to the current version."""
     if config_entry.version == 1:
+        _LOGGER.debug("Migrating %s config entry from version 1 to 2", DOMAIN)
         new_data = {**config_entry.data}
         if new_data.get(CONF_REGION) == Regions.UNITED_STATES.value:
             new_data[CONF_GET_CONTENT_BY] = GetContentBy.CITY_NA.value
+            if not new_data.get(CONF_CITY):
+                _LOGGER.warning(
+                    "Kleenex Pollen Radar: US config entry '%s' is missing a city — "
+                    "please delete and re-add the integration",
+                    config_entry.title,
+                )
         hass.config_entries.async_update_entry(config_entry, data=new_data, version=2)
 
     return True

--- a/custom_components/kleenex_pollenradar/api.py
+++ b/custom_components/kleenex_pollenradar/api.py
@@ -263,7 +263,7 @@ class PollenApi:
         """Decode the raw data from the NA (US) API."""
         # <div class="pollen-tracker one-slide-carousel">
         #   <div>
-        #     <p class="date-heading">Los Gatos | Tuesday April 14 </p>
+        #     <p class="date-heading">City | Tuesday April 14 </p>
         #     <div class="data-container">
         #       <ul class="diagram-list">
         #         <li class="... tree-learn-more ...">

--- a/custom_components/kleenex_pollenradar/api.py
+++ b/custom_components/kleenex_pollenradar/api.py
@@ -292,8 +292,7 @@ class PollenApi:
             return
 
         day_divs = [el for el in pollen_tracker.children if isinstance(el, Tag)]
-        if day_divs:
-            self._pollen = []
+        self._pollen = []
 
         na_pollen_types = {
             "trees": ("TreesRiskData", "tree-ppm"),
@@ -318,11 +317,10 @@ class PollenApi:
 
             for pollen_type, (risk_id, ppm_class) in na_pollen_types.items():
                 risk_input = day_div.find("input", attrs={"data-id": risk_id})
-                pollen_level = (
-                    risk_input.get("value", "")  # type: ignore[union-attr]
-                    if risk_input and isinstance(risk_input, Tag)
-                    else ""
-                ) or self.determine_level_by_count(pollen_type, 0)
+                if risk_input and isinstance(risk_input, Tag):
+                    pollen_level = risk_input.get("value", "") or self.determine_level_by_count(pollen_type, 0)
+                else:
+                    pollen_level = self.determine_level_by_count(pollen_type, 0)
 
                 ppm_el = day_div.find("p", class_=ppm_class)
                 count_unit = ppm_el.text.strip() if ppm_el and isinstance(ppm_el, Tag) else "0 PPM"

--- a/custom_components/kleenex_pollenradar/api.py
+++ b/custom_components/kleenex_pollenradar/api.py
@@ -32,6 +32,11 @@ class PollenApi:
         "weeds": "weed",
         "grass": "grass",
     }
+    _pollen_na_types: dict[str, tuple[str, str]] = {
+        "trees": ("TreesRiskData", "tree-ppm"),
+        "weeds": ("WeedsRiskData", "weed-ppm"),
+        "grass": ("GrassRiskData", "grass-ppm"),
+    }
     _found_city: str = ""
     _found_latitude: float = 0.0
     _found_longitude: float = 0.0
@@ -294,12 +299,6 @@ class PollenApi:
         day_divs = [el for el in pollen_tracker.children if isinstance(el, Tag)]
         self._pollen = []
 
-        na_pollen_types = {
-            "trees": ("TreesRiskData", "tree-ppm"),
-            "weeds": ("WeedsRiskData", "weed-ppm"),
-            "grass": ("GrassRiskData", "grass-ppm"),
-        }
-
         for day_div in day_divs:
             date_heading = day_div.find("p", class_="date-heading")
             if not date_heading or not isinstance(date_heading, Tag):
@@ -315,7 +314,7 @@ class PollenApi:
                 "date": pollen_date,
             }
 
-            for pollen_type, (risk_id, ppm_class) in na_pollen_types.items():
+            for pollen_type, (risk_id, ppm_class) in self._pollen_na_types.items():
                 risk_input = day_div.find("input", attrs={"data-id": risk_id})
                 if risk_input and isinstance(risk_input, Tag):
                     pollen_level = risk_input.get("value", "") or self.determine_level_by_count(pollen_type, 0)
@@ -323,7 +322,7 @@ class PollenApi:
                     pollen_level = self.determine_level_by_count(pollen_type, 0)
 
                 ppm_el = day_div.find("p", class_=ppm_class)
-                count_unit = ppm_el.text.strip() if ppm_el and isinstance(ppm_el, Tag) else "0 PPM"
+                count_unit = ppm_el.text.strip() if ppm_el else "0 PPM"
                 try:
                     pollen_count, unit_of_measure = count_unit.split(" ")
                     pollen[pollen_type] = int(pollen_count)

--- a/custom_components/kleenex_pollenradar/api.py
+++ b/custom_components/kleenex_pollenradar/api.py
@@ -68,16 +68,15 @@ class PollenApi:
             if success:
                 if self.get_content_by == GetContentBy.CITY_ITALY:
                     self.__decode_raw_data_italy()
+                elif self.get_content_by == GetContentBy.CITY_NA:
+                    self.__decode_raw_data_na()
                 else:
                     self.__decode_raw_data()
 
     async def __request_data(self) -> bool:
         """Request data from the API using city."""
-        params = {
-            "city"
-            if self.get_content_by == GetContentBy.CITY
-            else "location": self.city
-        }
+        param_key = "location" if self.get_content_by == GetContentBy.CITY_ITALY else "city"
+        params = {param_key: self.city}
         url = self.__get_url_by_region()
         _LOGGER.debug("Requesting data from URL: %s with params: %s", url, params)
         data = await self.__perform_request(url, params)
@@ -257,6 +256,86 @@ class PollenApi:
                                     "level": value[0],
                                 }
                                 pollen[f"{pollen_type}_details"].append(pollen_detail)
+
+            self._pollen.append(pollen)
+
+    def __decode_raw_data_na(self):
+        """Decode the raw data from the NA (US) API."""
+        # <div class="pollen-tracker one-slide-carousel">
+        #   <div>
+        #     <p class="date-heading">Los Gatos | Tuesday April 14 </p>
+        #     <div class="data-container">
+        #       <ul class="diagram-list">
+        #         <li class="... tree-learn-more ...">
+        #           <input data-id="TreesRiskData" type="hidden" value="high" />
+        #           <p class="ppm-level tree-ppm">357 PPM</p>
+        #         </li>
+        #         <li class="... grass-learn-more ...">
+        #           <input data-id="GrassRiskData" type="hidden" value="low" />
+        #           <p class="ppm-level grass-ppm">0 PPM</p>
+        #         </li>
+        #         <li class="... weed-learn-more ...">
+        #           <input data-id="WeedsRiskData" type="hidden" value="low" />
+        #           <p class="ppm-level weed-ppm">0 PPM</p>
+        #         </li>
+        #       </ul>
+        #     </div>
+        #   </div>
+        # </div>
+
+        soup = BeautifulSoup(self._raw_data, "html.parser")
+
+        self.__extract_location_data(soup)
+
+        pollen_tracker = soup.find("div", class_="pollen-tracker")
+        if not pollen_tracker or not isinstance(pollen_tracker, Tag):
+            return
+
+        day_divs = [el for el in pollen_tracker.children if isinstance(el, Tag)]
+        if day_divs:
+            self._pollen = []
+
+        na_pollen_types = {
+            "trees": ("TreesRiskData", "tree-ppm"),
+            "weeds": ("WeedsRiskData", "weed-ppm"),
+            "grass": ("GrassRiskData", "grass-ppm"),
+        }
+
+        for day_div in day_divs:
+            date_heading = day_div.find("p", class_="date-heading")
+            if not date_heading or not isinstance(date_heading, Tag):
+                continue
+            try:
+                day_no = int(date_heading.text.strip().split()[-1])
+            except (ValueError, IndexError):
+                continue
+
+            pollen_date = self.__determine_pollen_date(day_no)
+            pollen: dict[str, Any] = {
+                "day": day_no,
+                "date": pollen_date,
+            }
+
+            for pollen_type, (risk_id, ppm_class) in na_pollen_types.items():
+                risk_input = day_div.find("input", attrs={"data-id": risk_id})
+                pollen_level = (
+                    risk_input.get("value", "")  # type: ignore[union-attr]
+                    if risk_input and isinstance(risk_input, Tag)
+                    else ""
+                ) or self.determine_level_by_count(pollen_type, 0)
+
+                ppm_el = day_div.find("p", class_=ppm_class)
+                count_unit = ppm_el.text.strip() if ppm_el and isinstance(ppm_el, Tag) else "0 PPM"
+                try:
+                    pollen_count, unit_of_measure = count_unit.split(" ")
+                    pollen[pollen_type] = int(pollen_count)
+                except (ValueError, AttributeError):
+                    pollen[pollen_type] = 0
+                    unit_of_measure = "ppm"
+
+                pollen[f"{pollen_type}_level"] = pollen_level
+                pollen[f"{pollen_type}_unit_of_measure"] = unit_of_measure.lower()
+                pollen[f"{pollen_type}_details"] = []
 
             self._pollen.append(pollen)
 

--- a/custom_components/kleenex_pollenradar/config_flow.py
+++ b/custom_components/kleenex_pollenradar/config_flow.py
@@ -31,7 +31,7 @@ _LOGGER = logging.getLogger(__name__)
 class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
     """Handle a config flow for Kleenex pollen."""
 
-    VERSION = 1
+    VERSION = 2
     region: str = ""
     name: str = ""
     get_content_by: GetContentBy = GetContentBy.CITY
@@ -49,6 +49,8 @@ class ConfigFlow(config_entries.ConfigFlow, domain=DOMAIN):
             self.city = user_input[CONF_CITY]
             if self.region == Regions.ITALY.value:
                 self.get_content_by = GetContentBy.CITY_ITALY
+            elif self.region == Regions.UNITED_STATES.value:
+                self.get_content_by = GetContentBy.CITY_NA
             else:
                 self.get_content_by = GetContentBy.CITY
             user_input[CONF_GET_CONTENT_BY] = self.get_content_by.value

--- a/custom_components/kleenex_pollenradar/const.py
+++ b/custom_components/kleenex_pollenradar/const.py
@@ -63,9 +63,11 @@ class GetContentBy(Enum):
 
     CITY = "city"
     CITY_ITALY = "city_italy"
+    CITY_NA = "city_na"
 
 
 METHODS = {
     GetContentBy.CITY: "GetPollenContentCity",
     GetContentBy.CITY_ITALY: "GetPollenData",
+    GetContentBy.CITY_NA: "GetPollenContentNACity",
 }


### PR DESCRIPTION
## Problem

The US Kleenex website migrated to a new API endpoint (`GetPollenContentNACity`) with a different HTML structure. The integration was still calling the old endpoint (`GetPollenContentCity`), which no longer returns pollen data for US locations — causing all US sensors to show as **Unavailable**.

The incompatibility was documented in the README as a known limitation.

## Changes

### New `GetPollenContentNACity` parser

The new US HTML structure doesn't use `<button class="day-link">` elements. Instead, each day is a `<div>` inside `.pollen-tracker`, with:
- Date in `<p class="date-heading">City | Weekday Month DD</p>`
- Risk level in `<input data-id="TreesRiskData" value="high" />`
- PPM count in `<p class="ppm-level tree-ppm">357 PPM</p>`

Location data (`cityName`, `pollenlat`, `pollenlng`) is still provided in the same hidden input format, so `__extract_location_data()` is reused unchanged.

### Config entry migration (v1 → v2)

`async_migrate_entry()` is added to automatically upgrade existing US config entries to use the new `CITY_NA` content type, so existing users don't need to delete and re-add the integration.

### Summary of code changes

- `const.py`: Add `GetContentBy.CITY_NA` enum value and `GetPollenContentNACity` method mapping
- `api.py`: Add `__decode_raw_data_na()` parser; dispatch to it from `refresh_data()`; simplify `__request_data()` params logic
- `config_flow.py`: Use `CITY_NA` for United States region; bump `VERSION` to `2`
- `__init__.py`: Add `async_migrate_entry()` to auto-migrate existing US entries
- `README.md`: Remove footnote noting US API incompatibility

## Testing

Tested against `https://www.kleenex.com/api/sitecore/Pollen/GetPollenContentNACity?city=San-Francisco` — all three pollen types (trees, grass, weeds) parse correctly with level and PPM values. Verified working in a live Home Assistant instance.

## Screenshot
<img width="670" height="716" alt="Screenshot 2026-04-14 at 4 49 00 AM" src="https://github.com/user-attachments/assets/df113de5-a258-4a61-b2a1-5066a203f36a" />
