### PR TITLE
Bump manifest version to 1.6.0 to match release tag

### DIFF
--- a/custom_components/kleenex_pollenradar/manifest.json
+++ b/custom_components/kleenex_pollenradar/manifest.json
@@ -13,6 +13,6 @@
   "issue_tracker": "https://github.com/MarcoGos/kleenex_pollenradar/issues",
   "requirements": ["beautifulsoup4>=4.10.0"],
   "ssdp": [],
-  "version": "1.5.3",
+  "version": "1.6.0",
   "zeroconf": []
 }


### PR DESCRIPTION
The v1.6.0 release was tagged and published, but manifest.json still contains "version": "1.5.3". As a result, Home Assistant and HACS display 1.5.3 for users who have installed v1.6.0, making it appear that the update did not apply. This one-line change brings the manifest in sync with the release tag.